### PR TITLE
Allow working with an SQS queue that doesn't include routes [WIP]

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -156,10 +156,15 @@ func (c *consumer) Consume() {
 		}
 
 		for _, m := range output.Messages {
+			// If the Message doesn't have a "route" attribute, the default route is "".
+			// (This allows us to run a queue without routing.)
+			if m.MessageAttributes == nil {
+				m.MessageAttributes = defaultSQSAttributes("")
+			}
 			if _, ok := m.MessageAttributes["route"]; !ok {
-				//a message will be sent to the DLQ automatically after 4 tries if it is received but not deleted
-				c.Logger().Println(ErrNoRoute.Error())
-				continue
+				t := "String"
+				v := ""
+				m.MessageAttributes["route"] = &sqs.MessageAttributeValue{DataType: &t, StringValue: &v}
 			}
 
 			jobs <- newMessage(m)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -188,5 +188,19 @@ func TestRun(t *testing.T) {
 			t.Errorf("unexpected result, expected %v, got %v", nil, err)
 		}
 	})
-
 }
+
+// // TODO:fix `panic: runtime error: invalid memory address or nil pointer dereference`
+// func TestRunNoAttributes(t *testing.T) {
+// 	c := getConsumer(t)
+// 	a := []Adapter{WithRecovery(func() {})}
+// 	c.RegisterHandler("", test, a...)
+
+// 	t.Run("no_attributes", func(t *testing.T) {
+// 		c.Message(context.TODO(), "post-worker", "", testStruct{"val"})
+// 		m := retrieveMessage(t, c)
+// 		if err := c.run(m.(*message)); err != nil {
+// 			t.Errorf("should not return an error, got %v", err)
+// 		}
+// 	})
+// }


### PR DESCRIPTION
The purpose of this PR is to allow using SQS without requiring producers to set a "route" attribute on every message. It accomplishes this by setting the route attribute as "" if there is none. 

With this approach, the consumer can register a "" route to handle these messages.

This is a work-in-progress PR: 

(1) This PR only addresses the consumer side of the interaction for the time being.
(2) In order to operationalize the test case, there is a need to fix other issues in message sending via `consumer.Message()` for this use case. 

But before going further down that road, I'd like your feedback as to whether the proposed approach is something that you would support or whether you would prefer a different mechanism for supporting routeless queues.