### PR TITLE
Fix custom logger assignment

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -75,8 +75,8 @@ func NewConsumer(c Config, queueName string) (Consumer, error) {
 		extensionLimit:    2,
 	}
 
-	if c.Logger == nil {
-		cons.logger = &defaultLogger{}
+	if c.Logger != nil {
+		cons.logger = c.Logger
 	}
 
 	if c.VisibilityTimeout != 0 {


### PR DESCRIPTION
* In `consumer.go` the `NewConsumer` function was testing if the `Logger` attribute on the Config struct is `nil` and if it was it assigned the consumer logger to `&defaultLogger{}` but if the Config.Logger is not nil its value was never getting set on the consumer leaving `consumer.logger == nil`

* In the `Logger` method on 109 there is a check for whether `consumer.logger == nil` and if it is we return `&defaultLogger{}`

* Combined these to pieces of logic result in always ignoring a custom Logger attribute when it is set on Config.

* This switches the logic in `NewConsumer` to match the pattern for other optional attributes by checking if the `Logger` attribute on the provided config is `!= nil` and setting consumer's logger to the provided logger

* If there is no logger assigned on Config `consumer.logger` will remain `nil` and the `Logger` function will dutifly return a `&defaultLogger{}`